### PR TITLE
Use crx to pack Chrome Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/
 dev/
 
 *.zip
+*.crx
+*.pem

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@ build/
 dev/
 
 *.zip
+*.crx
+*.pem

--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ This boilerplate uses `Webpack` and `react-transform`, and use `Redux`. You can 
 npm run build
 ```
 
-## Build & Compress ZIP file
+## Build & Compress
 
 ```bash
-# compress build folder to archive.zip
+# compress build folder to react-crx.zip & .crx
 npm run compress
 ```
+
+You can add custom `key.pem` in `build` folder.
 
 ## Test
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -3,7 +3,6 @@ import gulp from 'gulp';
 import gutil from 'gulp-util';
 import jade from 'gulp-jade';
 import rename from 'gulp-rename';
-import zip from 'gulp-zip';
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import prodConfig from './webpack/prod.config';
@@ -91,16 +90,5 @@ gulp.task('copy:build', () => {
   gulp.src('./chrome/assets/**/*').pipe(gulp.dest('./build'));
 });
 
-/*
- * compress task
- */
-
-gulp.task('zip:compress', () => {
-  gulp.src('build/**')
-    .pipe(zip('archive.zip'))
-    .pipe(gulp.dest('.'));
-});
-
 gulp.task('default', ['replace-webpack-code', 'webpack-dev-server', 'views:dev', 'copy:dev']);
 gulp.task('build', ['replace-webpack-code', 'webpack:build', 'views:build', 'copy:build']);
-gulp.task('compress', ['zip:compress']);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-plugin-react-transform": "^1.1.1",
     "chai": "^3.2.0",
     "chromedriver": "^2.19.0",
+    "crx": "^3.0.3",
     "eslint": "^1.1.0",
     "eslint-config-airbnb": "0.0.7",
     "eslint-plugin-react": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "gulp",
     "build": "BABEL_ENV=production gulp build",
-    "compress": "npm run build && gulp compress",
-    "clean": "rm -rf build/ && rm -rf dev/ && rm -f archive.zip",
+    "compress": "npm run build && crx pack build --zip-output react-crx.zip -o react-crx.crx",
+    "clean": "rm -rf build/ && rm -rf dev/ && rm -f *.zip && rm -f *.crx",
     "test-crdv": "chromedriver",
     "test:eslint": "eslint .",
     "test:app": "BABEL_ENV=test mocha --recursive --compilers js:babel-core/register test/app",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "gulp-jade": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.5",
-    "gulp-zip": "^3.0.2",
     "jsdom": "^6.5.1",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",


### PR DESCRIPTION
Remove gulp compress task, using `crx` CLI tool to pack `.zip` and `.crx`.

You can add custom `key.pem` to `build/` folder.

Unfortunately crx generateUpdateXML is not supported in cli tool, although we can do it with `require('crx')`, but I wanted to keep it simple. It may will do in the future, and will add some guidelines.