### PR TITLE
Fix matching urls to inject

### DIFF
--- a/chrome/app/background/inject.js
+++ b/chrome/app/background/inject.js
@@ -5,7 +5,7 @@ const arrowURLs = [ 'https://github.com' ];
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
   if (changeInfo.status !== 'loading') return;
-  const matched = arrowURLs.every(url => !!tab.url.match(url));
+  const matched = tab.url.match(new RegExp(arrowURLs.join('|')));
   if (!matched) return;
 
   co(function *() {


### PR DESCRIPTION
The previous condition impose that the `tab.url` matches all the urls, which will never be true if we have more than one value in `arrowUrls`.