### PR TITLE
Use webpack-httpolyglot-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ $ npm install
 * Run script
 ```bash
 # build files to './dev'
-# start WebpackDevServer
+# start webpack development server
 $ npm run dev
 ```
-* Allow `https://localhost:3000` connections. (Because `injectpage` injected GitHub (https) pages, so `webpack-dev-server` procotol must be https.)
+* If you're developing Inject page, please allow `https://localhost:3000` connections. (Because `injectpage` injected GitHub (https) pages, so webpack server procotol must be https.)
 * [Load unpacked extensions](https://developer.chrome.com/extensions/getstarted#unpacked) with `./dev` folder.
 
 #### React/Redux hot reload

--- a/chrome/extension/background/inject.js
+++ b/chrome/extension/background/inject.js
@@ -12,7 +12,7 @@ function loadScript(name, tabId, cb) {
     chrome.tabs.executeScript(tabId, { file: `/js/${name}.bundle.js`, runAt: 'document_end' }, cb);
   } else {
     // dev: async fetch bundle
-    fetch(`https://localhost:3000/js/${name}.bundle.js`)
+    fetch(`http://localhost:3000/js/${name}.bundle.js`)
     .then(res => res.text())
     .then(fetchRes => {
       // Load redux-devtools-extension inject bundle,

--- a/chrome/manifest.dev.json
+++ b/chrome/manifest.dev.json
@@ -19,5 +19,5 @@
     "page": "background.html"
   },
   "permissions": [ "contextMenus", "management", "tabs", "storage", "https://github.com/*" ],
-  "content_security_policy": "default-src 'self'; script-src 'self' https://localhost:3000 'unsafe-eval'; connect-src https://localhost:3000 wss://localhost:3000; style-src * 'unsafe-inline' 'self' blob:; img-src 'self' data:;"
+  "content_security_policy": "default-src 'self'; script-src 'self' http://localhost:3000 https://localhost:3000 'unsafe-eval'; connect-src http://localhost:3000 https://localhost:3000; style-src * 'unsafe-inline' 'self' blob:; img-src 'self' data:;"
 }

--- a/chrome/views/background.jade
+++ b/chrome/views/background.jade
@@ -2,4 +2,4 @@ doctype html
 
 html
   head
-    script(src=env == 'prod' ? '/js/background.bundle.js' : 'https://localhost:3000/js/background.bundle.js')
+    script(src=env == 'prod' ? '/js/background.bundle.js' : 'http://localhost:3000/js/background.bundle.js')

--- a/chrome/views/popup.jade
+++ b/chrome/views/popup.jade
@@ -11,4 +11,4 @@ html
     #root
     if env !== 'prod'
       script(src='chrome-extension://lmhkpmbekcpmknklioeibfkpmmfibljd/js/inject.bundle.js')
-    script(src=env == 'prod' ? '/js/todoapp.bundle.js' : 'https://localhost:3000/js/todoapp.bundle.js')
+    script(src=env == 'prod' ? '/js/todoapp.bundle.js' : 'http://localhost:3000/js/todoapp.bundle.js')

--- a/chrome/views/window.jade
+++ b/chrome/views/window.jade
@@ -8,4 +8,4 @@ html
     #root
     if env !== 'prod'
       script(src='chrome-extension://lmhkpmbekcpmknklioeibfkpmmfibljd/js/inject.bundle.js')
-    script(src=env == 'prod' ? '/js/todoapp.bundle.js' : 'https://localhost:3000/js/todoapp.bundle.js')
+    script(src=env == 'prod' ? '/js/todoapp.bundle.js' : 'http://localhost:3000/js/todoapp.bundle.js')

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "shelljs": "^0.7.0",
     "sinon": "^1.17.1",
     "style-loader": "^0.13.1",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.10.1"
+    "webpack": "^1.13.0",
+    "webpack-httpolyglot-server": "^0.2.0"
   },
   "dependencies": {
     "bluebird": "^3.3.4",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,4 +1,6 @@
 const tasks = require('./tasks');
+const createWebpackServer = require('webpack-httpolyglot-server');
+const devConfig = require('../webpack/dev.config');
 
 tasks.replaceWebpack();
 console.log('[Copy assets]');
@@ -7,6 +9,10 @@ tasks.copyAssets('dev');
 
 console.log('[Webpack Dev]');
 console.log('-'.repeat(80));
-console.log('Please allow `https://localhost:3000` connections in Google Chrome');
-console.log('and load unpacked extensions with `./dev` folder.  (see https://developer.chrome.com/extensions/getstarted#unpacked)\n');
-exec('webpack-dev-server --config=webpack/dev.config.js --no-info --hot --inline --colors');
+console.log('If you\'re developing Inject page,');
+console.log('please allow `https://localhost:3000` connections in Google Chrome,');
+console.log('and load unpacked extensions with `./dev` folder. (see https://developer.chrome.com/extensions/getstarted#unpacked)\n');
+createWebpackServer(devConfig, {
+  host: 'localhost',
+  port: 3000
+});

--- a/webpack/test.config.js
+++ b/webpack/test.config.js
@@ -1,11 +1,11 @@
 // for babel-plugin-webpack-loaders
-const devConfig = require('./dev.config');
+const config = require('./prod.config');
 
 module.exports = {
   output: {
     libraryTarget: 'commonjs2'
   },
   module: {
-    loaders: devConfig.module.loaders.slice(1)  // remove babel-loader
+    loaders: config.module.loaders.slice(1)  // remove babel-loader
   }
 };


### PR DESCRIPTION
This solves the problem of long-standing - Due to injectpage feature, we only use https webpack server in development mode, so you need to allow https connection in any case.

#### The solution of use `webpack-httpolyglot-server`

* Just use http on Window, Popup, Background
* The `publicPath` using `//` as prefix for injectpage bundle, which means it will select protocol of current injectpage. Only when you are in https page, you need to allow https connection.