### PR TITLE
Dynamic webpack publicPath entry

### DIFF
--- a/chrome/extension/inject.js
+++ b/chrome/extension/inject.js
@@ -31,7 +31,7 @@ class InjectApp extends Component {
             }}
             frameBorder={0}
             allowTransparency="true"
-            src={chrome.extension.getURL('inject.html')}
+            src={chrome.extension.getURL(`inject.html?protocol=${location.protocol}`)}
           />
         </Dock>
       </div>

--- a/webpack/customPublicPath.js
+++ b/webpack/customPublicPath.js
@@ -1,0 +1,16 @@
+/* global __webpack_public_path__ __HOST__ __PORT__ */
+/* eslint no-native-reassign: 0 camelcase: 0 */
+
+if (process.env.NODE_ENV === 'production') {
+  __webpack_public_path__ = chrome.extension.getURL('/js');
+} else {
+  // In development mode,
+  // the iframe of injectpage cannot get correct path,
+  // it need to get parent page protocol.
+  const path = `//${__HOST__}:${__PORT__}/js`;
+  if (location.protocol === 'https:' || location.search.indexOf('protocol=https') !== -1) {
+    __webpack_public_path__ = `https:${path}`;
+  } else {
+    __webpack_public_path__ = `http:${path}`;
+  }
+}

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -3,32 +3,37 @@ const webpack = require('webpack');
 
 const host = 'localhost';
 const port = 3000;
-const hotScript = `webpack-hot-middleware/client?path=http://${host}:${port}/__webpack_hmr`;
+const customPath = path.join(__dirname, './customPublicPath');
+const hotScript = 'webpack-hot-middleware/client?path=/__webpack_hmr&dynamicPublicPath=true';
 
 const baseDevConfig = () => ({
   devtool: 'eval-cheap-module-source-map',
   entry: {
-    todoapp: [hotScript, path.join(__dirname, '../chrome/extension/todoapp')],
-    background: [hotScript, path.join(__dirname, '../chrome/extension/background')],
+    todoapp: [customPath, hotScript, path.join(__dirname, '../chrome/extension/todoapp')],
+    background: [customPath, hotScript, path.join(__dirname, '../chrome/extension/background')],
   },
   devMiddleware: {
-    publicPath: `http://${host}:${port}/js/`,
+    publicPath: `http://${host}:${port}/js`,
     stats: {
       colors: true
     },
     noInfo: true
   },
+  hotMiddleware: {
+    path: '/js/__webpack_hmr'
+  },
   output: {
     path: path.join(__dirname, '../dev/js'),
     filename: '[name].bundle.js',
-    chunkFilename: '[id].chunk.js',
-    publicPath: `http://${host}:${port}/js/`
+    chunkFilename: '[id].chunk.js'
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.IgnorePlugin(/[^/]+\/[\S]+.prod$/),
     new webpack.DefinePlugin({
+      __HOST__: `'${host}'`,
+      __PORT__: port,
       'process.env': {
         NODE_ENV: JSON.stringify('development')
       }
@@ -58,16 +63,15 @@ const baseDevConfig = () => ({
 
 const injectPageConfig = baseDevConfig();
 injectPageConfig.entry = [
-  `webpack-hot-middleware/client?path=//${host}:${port}/__webpack_hmr_for_injectpage`,
+  customPath,
   path.join(__dirname, '../chrome/extension/inject')
 ];
-injectPageConfig.hotMiddleware = {
-  path: '/__webpack_hmr_for_injectpage'
-};
+delete injectPageConfig.hotMiddleware;
+delete injectPageConfig.module.loaders[0].query;
+injectPageConfig.plugins.shift(); // remove HotModuleReplacementPlugin
 injectPageConfig.output = {
   path: path.join(__dirname, '../dev/js'),
   filename: 'inject.bundle.js',
-  publicPath: `//${host}:${port}/js/`
 };
 const appConfig = baseDevConfig();
 

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,11 +1,12 @@
 const path = require('path');
 const webpack = require('webpack');
+const customPath = path.join(__dirname, './customPublicPath');
 
 module.exports = {
   entry: {
-    todoapp: path.join(__dirname, '../chrome/extension/todoapp'),
-    background: path.join(__dirname, '../chrome/extension/background'),
-    inject: path.join(__dirname, '../chrome/extension/inject')
+    todoapp: [customPath, path.join(__dirname, '../chrome/extension/todoapp')],
+    background: [customPath, path.join(__dirname, '../chrome/extension/background')],
+    inject: [customPath, path.join(__dirname, '../chrome/extension/inject')]
   },
   output: {
     path: path.join(__dirname, '../build/js'),


### PR DESCRIPTION
Related to #40, https://github.com/jhen0409/react-chrome-extension-boilerplate/pull/37#issuecomment-217719393.

* The iframe of injectpage cannot get correct path, it need to get parent page protocol.
  - In development mode, the publicPath must be `{protocol}://localhost:3000/js`
  - In production mode, the publicPath must be `chrome-extension://{id}/js`
* Remove injectpage HMR, looks GitHub updated CSP.  
  [The shield icon](https://github.com/zalmoxisus/crossbuilder/issues/5#issuecomment-147779849) also not appeared. (cc @zalmoxisus)